### PR TITLE
Add InstallSpec design documents for generic installer architecture

### DIFF
--- a/docs/design/generic-installer-architecture.md
+++ b/docs/design/generic-installer-architecture.md
@@ -8,7 +8,7 @@ status: "draft"
 
 # Generic Config‑Driven Installer Architecture
 
-> 📄 **Document series overview**
+> 📄 **Document series overview**  
 > This file lays out the *architecture* of a generic, config‑driven installer
 > pipeline.  The concrete specification of the on‑disk schema referred to in
 > this document lives in **[InstallSpec v1](install-spec-v1.md)** which should be
@@ -23,7 +23,7 @@ We need a pluggable, data‑source‑agnostic architecture that—given minimal 
 - Extract a **pure InstallSpec** that fully describes name, version placeholder, supported platforms, asset templates, checksum/verification settings, etc.
 - Define a **SourceAdapter** interface to populate that InstallSpec from any origin.
 - Maintain a single **ScriptGenerator** component that transforms InstallSpec → installer code (shell, PowerShell, …).
-- Preserve existing GoReleaser flow as one SourceAdapter implementation and default path for backward compatibility.
+- Preserve existing GoReleaser flow as one SourceAdapter implementation.
 
 ## 3. High‑Level Architecture
 
@@ -44,83 +44,83 @@ We need a pluggable, data‑source‑agnostic architecture that—given minimal 
   - checksum definition (file, algorithm, embedded checksums)
   - attestation verification settings
   - unpack options (strip components)
+  - For detailed schema definition, see [InstallSpec v1](install-spec-v1.md)
 - **ScriptBuilder**: generates installer scripts
   - powered by Go `text/template` (+ sprig)
   - supports POSIX shell & PowerShell; template sets are pluggable
   - injects download, checksum verify, attestation, retry, flags
 
-## 4. Example InstallSpec Schema (YAML)
-```yaml
-name: mytool
-version: 1.2.3
-download:
-  base_url: https://github.com/OWNER/REPO/releases/download/v{{version}}
-assets:
-  - os: linux
-    arch: amd64
-    file: mytool_{{version}}_linux_amd64.tar.gz
-    checksum: SHA256SUMS
-  - os: darwin
-    arch: arm64
-    file: mytool_{{version}}_darwin_arm64.tar.gz
-verify:
-  checksum: true
-  attestation: true
-  embedded_checksums:  # Pre-verified checksums embedded in the script
-    v1.2.3:
-      - filename: "mytool_1.2.3_linux_amd64.tar.gz"
-        hash: "1234567890abcdef..."
-      - filename: "mytool_1.2.3_darwin_arm64.tar.gz"
-        hash: "abcdef1234567890..."
-templates:
-  shell: default_install.sh.tmpl
-  powershell: default_install.ps1.tmpl
+## 4. Two-Step Workflow
+
+The new architecture introduces a two-step workflow to simplify the process:
+
+1. **Config Generation**: First generate the InstallSpec config
+   ```bash
+   goinstaller init-config --source [goreleaser|github|cli] [options]
+   ```
+
+2. **Script Generation**: Then generate the installer script from the config
+   ```bash
+   goinstaller generate-script --config install-spec.yaml [options]
+   ```
+
+Additionally, a utility command is provided to embed checksums into an existing config:
+
+```bash
+goinstaller embed-checksums --config install-spec.yaml --checksum-file SHA256SUMS
 ```
 
-## 5. CLI UX
+This separation allows for:
+- Better validation and inspection of the config before script generation
+- Reuse of configs across multiple script generations
+- Simplified script generation logic
+- Easier testing and debugging
+- Ability to add checksums to existing configs from external checksum files
+
+## 5. CLI UX Examples
+
+> **Note**: These examples represent the current design thinking and may evolve during implementation. The exact command names, flags, and syntax are subject to change.
+
 ```bash
-# Default (GoReleaser)
-goinstaller generate \
+# Step 1: Generate config from GoReleaser
+goinstaller init-config \
   --source goreleaser \
   --file .goreleaser.yml \
-  --output install.sh
+  --output install-spec.yaml
 
-# GitHub Releases
-goinstaller generate \
+# Step 1: Generate config from GitHub Releases
+goinstaller init-config \
   --source github \
   --repo owner/repo \
   --tag v1.2.3 \
   --asset-pattern "{{name}}_{{version}}_{{os}}_{{arch}}.tar.gz" \
-  --output install.sh
+  --output install-spec.yaml
 
-# Manual config
-goinstaller generate \
-  --source manual \
-  --config myconfig.yml \
-  --output install.sh
-
-# Pure flags
-goinstaller generate \
+# Step 1: Generate config from CLI flags
+goinstaller init-config \
   --source cli \
   --name mytool \
   --version 0.9.0 \
   --base-url https://example.com/downloads \
   --asset linux/amd64=mytool_{{version}}_linux_amd64.tgz \
-  --output install.sh
+  --output install-spec.yaml
 
-# With pre-verified checksums
-goinstaller generate \
-  --source github \
-  --repo owner/repo \
-  --tag v1.2.3 \
-  --pre-verify-checksums \
+# Optional: Embed checksums into an existing config
+goinstaller embed-checksums \
+  --config install-spec.yaml \
+  --checksum-file SHA256SUMS \
+  --version v1.2.3
+
+# Step 2: Generate script from config
+goinstaller generate-script \
+  --config install-spec.yaml \
   --output install.sh
 ```
 
 ## 6. Integration with Existing Code
 ```
 goinstaller/
-├── cmd/goinstaller/main.go       # add --source flag & dispatcher
+├── cmd/goinstaller/main.go       # add subcommands for init-config and generate-script
 ├── internal/
 │   ├── datasource/               # new package
 │   │   ├── interface.go          # SourceAdapter interface & options
@@ -136,47 +136,42 @@ goinstaller/
     └── verify/                   # checksum & attestation helpers
 ```
 
-## 7. Compatibility & Migration
-- Default (no `--source`): legacy GoReleaser path
-- Existing flags deprecated in favor of explicit `--source`
-- Support overrides via CLI and manual YAML
-
-## 8. Embedded Checksums Benefits
+## 7. Embedded Checksums Benefits
 
 The embedded checksums feature provides several significant advantages:
 
-### 8.1 Performance Improvements
+### 7.1 Performance Improvements
 - **Reduced HTTP Requests**: Eliminates the need to download separate checksum files during installation, reducing the number of HTTP requests by at least one per installation.
 - **Faster Installations**: Installation completes more quickly, especially on slower networks, as there's no need to wait for additional checksum file downloads.
 - **Optimized Verification Flow**: When the installer script itself is verified with attestation, the embedded checksums can be trusted implicitly, allowing the binary verification process to be streamlined or even skipped in certain scenarios, further accelerating the installation process.
 
-### 8.2 Reliability Enhancements
+### 7.2 Reliability Enhancements
 - **Offline Installation Support**: Enables completely offline installations once the installer script and binary are downloaded, as no additional network requests for checksum files are needed.
 - **Reduced Network Dependency**: Less susceptible to temporary network issues or checksum file server unavailability.
 - **Consistent Verification**: Ensures the same checksums are used for verification regardless of network conditions or changes to remote checksum files.
 
-### 8.3 Security Considerations
+### 7.3 Security Considerations
 - **Pre-verified Integrity**: Checksums can be pre-verified by the script generator using `gh attestation verify` or other secure methods before embedding.
 - **Tamper Resistance**: Makes it harder for attackers to substitute malicious checksums, as they would need to modify the installer script itself (which could also be signed or verified).
 - **Audit Trail**: Provides a clear record of which checksums were used for verification at the time the installer was generated.
 - **Trust Chain**: When the installer script is verified with attestation, the embedded checksums inherit this trust, creating a stronger end-to-end security model.
 
-### 8.4 User Experience
+### 7.4 User Experience
 - **Simplified Installation**: Users don't need to worry about checksum file availability or format.
 - **Consistent Behavior**: Installation process behaves the same way across different environments and network conditions.
 - **Transparent Verification**: Users can inspect the embedded checksums in the installer script before running it.
 
 This feature is particularly valuable for enterprise environments with strict security policies, air-gapped systems, or deployments in regions with unreliable internet connectivity.
 
-## 9. Implementation Roadmap
+## 8. Implementation Roadmap
 1. Phase 1: Extract InstallSpec & SourceAdapter interface; migrate current GoReleaser code
-2. Phase 2: Wire CLI flag parsing to select SourceAdapter
+2. Phase 2: Implement two-step workflow with init-config and generate-script commands
 3. Phase 3: Implement GitHub Probe adapter (API calls, naming heuristics)
 4. Phase 4: Add File & Flags adapters
-5. Phase 5: Update templates, tests, examples, docs
-6. Phase 6: Implement embedded checksums feature for offline installation
+5. Phase 5: Implement embed-checksums command for adding checksums to existing configs
+6. Phase 6: Update templates, tests, examples, docs
 
-## 10. Risks & Mitigations
+## 9. Risks & Mitigations
 - Naming inference may require pattern flags for edge cases
 - GitHub rate limits: support unauthenticated vs token flows
 - Template versioning: allow per‑project overrides and locking

--- a/docs/design/generic-installer-architecture.md
+++ b/docs/design/generic-installer-architecture.md
@@ -52,7 +52,7 @@ We need a pluggable, data‑source‑agnostic architecture that—given minimal 
   - unpack options (strip components)
   - For detailed schema definition, see [InstallSpec v1](install-spec-v1.md)
 - **ScriptBuilder**: generates installer scripts
-  - powered by Go `text/template` (+ sprig)
+  - powered by Go `text/template`
   - outputs POSIX `sh` installer scripts
   - injects download, checksum verify, attestation, retry, flags
 

--- a/docs/design/generic-installer-architecture.md
+++ b/docs/design/generic-installer-architecture.md
@@ -8,6 +8,12 @@ status: "draft"
 
 # Generic Config‑Driven Installer Architecture
 
+> 📄 **Document series overview**  
+> This file lays out the *architecture* of a generic, config‑driven installer
+> pipeline.  The concrete specification of the on‑disk schema referred to in
+> this document lives in **[InstallSpec v1](install-spec-v1.md)** which should be
+> read together with this file.
+
 ## 1. Background & Motivation
 Today, `goinstaller` only supports reading a GoReleaser YAML (`.goreleaser.yml`) to generate a shell installer script.
 Many projects either do not use GoReleaser or have custom asset naming conventions and release workflows.

--- a/docs/design/generic-installer-architecture.md
+++ b/docs/design/generic-installer-architecture.md
@@ -1,0 +1,133 @@
+---
+title: "InstallSpec‑Driven Installer Architecture"
+date: "2025-04-19"
+author: "goinstaller Team"
+version: "0.2.0"
+status: "draft"
+---
+
+# Generic Config‑Driven Installer Architecture
+
+## 1. Background & Motivation
+Today, `goinstaller` only supports reading a GoReleaser YAML (`.goreleaser.yml`) to generate a shell installer script.
+Many projects either do not use GoReleaser or have custom asset naming conventions and release workflows.
+We need a pluggable, data‑source‑agnostic architecture that—given minimal inputs via CLI flags, manual config, GitHub API, etc.—can generate the same installer logic without being tightly coupled to GoReleaser.
+
+## 2. Goals
+- Extract a **pure InstallSpec** that fully describes name, version placeholder, supported platforms, asset templates, checksum/verification settings, etc.
+- Define a **SourceAdapter** interface to populate that InstallSpec from any origin.
+- Maintain a single **ScriptGenerator** component that transforms InstallSpec → installer code (shell, PowerShell, …).
+- Preserve existing GoReleaser flow as one SourceAdapter implementation and default path for backward compatibility.
+
+## 3. High‑Level Architecture
+
+```text
+┌──────────────┐    ┌───────────────┐    ┌───────────────────┐
+│ SourceAdapter│ ─> │  InstallSpec │ ─> │  ScriptBuilder   │ ─> install.sh
+└──────────────┘    └───────────────┘    └───────────────────┘
+```
+
+- **SourceAdapter**: interface `Detect(ctx, in DetectInput) (InstallSpec, error)`
+  - goreleaserAdapter (existing `.goreleaser.yml`)
+  - githubProbeAdapter (GitHub Releases API, asset inspection)
+  - flagsAdapter (CLI flags for name, patterns, etc.)
+  - fileAdapter (user‑supplied `install-spec.yaml`)
+- **InstallSpec**: Go struct/YAML schema that holds:
+  - `name`, `repo`, `version` placeholder
+  - per‑platform archives (`os`, `arch`, `asset` template, `bin`)
+  - checksum definition (file, algorithm)
+  - unpack options (strip components)
+- **ScriptBuilder**: generates installer scripts
+  - powered by Go `text/template` (+ sprig)
+  - supports POSIX shell & PowerShell; template sets are pluggable
+  - injects download, checksum verify, attestation, retry, flags
+
+## 4. Example InstallSpec Schema (YAML)
+```yaml
+name: mytool
+version: 1.2.3
+download:
+  base_url: https://github.com/OWNER/REPO/releases/download/v{{version}}
+assets:
+  - os: linux
+    arch: amd64
+    file: mytool_{{version}}_linux_amd64.tar.gz
+    checksum: SHA256SUMS
+  - os: darwin
+    arch: arm64
+    file: mytool_{{version}}_darwin_arm64.tar.gz
+verify:
+  checksum: true
+  attestation: true
+templates:
+  shell: default_install.sh.tmpl
+  powershell: default_install.ps1.tmpl
+```
+
+## 5. CLI UX
+```bash
+# Default (GoReleaser)
+goinstaller generate \
+  --source goreleaser \
+  --file .goreleaser.yml \
+  --output install.sh
+
+# GitHub Releases
+goinstaller generate \
+  --source github \
+  --repo owner/repo \
+  --tag v1.2.3 \
+  --asset-pattern "{{name}}_{{version}}_{{os}}_{{arch}}.tar.gz" \
+  --output install.sh
+
+# Manual config
+goinstaller generate \
+  --source manual \
+  --config myconfig.yml \
+  --output install.sh
+
+# Pure flags
+goinstaller generate \
+  --source cli \
+  --name mytool \
+  --version 0.9.0 \
+  --base-url https://example.com/downloads \
+  --asset linux/amd64=mytool_{{version}}_linux_amd64.tgz \
+  --output install.sh
+```
+
+## 6. Integration with Existing Code
+```
+goinstaller/
+├── cmd/goinstaller/main.go       # add --source flag & dispatcher
+├── internal/
+│   ├── datasource/               # new package
+│   │   ├── interface.go          # SourceAdapter interface & options
+│   │   ├── goreleaser.go         # existing logic moved here
+│   │   ├── github.go             # GitHub probe implementation
+│   │   ├── flags.go              # flags → InstallSpec
+│   │   └── file.go               # install-spec.yaml parser
+│   ├── config/                   # InstallSpec struct + YAML schema
+│   └── shell/                    # existing generator refactored as ScriptBuilder
+│       ├── generator.go
+│       └── templates/
+└── pkg/
+    └── verify/                   # checksum & attestation helpers
+```
+
+## 7. Compatibility & Migration
+- Default (no `--source`): legacy GoReleaser path
+- Existing flags deprecated in favor of explicit `--source`
+- Support overrides via CLI and manual YAML
+
+## 8. Implementation Roadmap
+1. Phase 1: Extract InstallSpec & SourceAdapter interface; migrate current GoReleaser code
+2. Phase 2: Wire CLI flag parsing to select SourceAdapter
+3. Phase 3: Implement GitHub Probe adapter (API calls, naming heuristics)
+4. Phase 4: Add File & Flags adapters
+5. Phase 5: Update templates, tests, examples, docs
+
+## 9. Risks & Mitigations
+- Naming inference may require pattern flags for edge cases
+- GitHub rate limits: support unauthenticated vs token flows
+- Template versioning: allow per‑project overrides and locking

--- a/docs/design/install-spec-v1.md
+++ b/docs/design/install-spec-v1.md
@@ -12,7 +12,7 @@ parent: generic-installer-architecture.md
 This document is **part 2** of the *Generic Config‑Driven Installer* series.  It
 defines **InstallSpec v1**, the first public, stable on‑disk schema that
 `binstaller` consumes to generate cross‑platform installer scripts (see
-*[Architecture]*](generic-installer-architecture.md) for the high‑level design).
+*[Architecture](generic-installer-architecture.md)* for the high‑level design).
 
 InstallSpec focuses on *what to install*; *how the file was produced*
 (GoReleaser, hand‑crafted, Buildkite, …) is out of scope and handled by the

--- a/docs/design/install-spec-v1.md
+++ b/docs/design/install-spec-v1.md
@@ -11,7 +11,7 @@ parent: generic-installer-architecture.md
 
 This document is **part 2** of the *Generic Config‑Driven Installer* series.  It
 defines **InstallSpec v1**, the first public, stable on‑disk schema that
-`goinstaller` consumes to generate cross‑platform installer scripts (see
+`binstaller` consumes to generate cross‑platform installer scripts (see
 *[Architecture]*](generic-installer-architecture.md) for the high‑level design).
 
 InstallSpec focuses on *what to install*; *how the file was produced*
@@ -24,7 +24,7 @@ one‑liner without constraining their build pipeline to GoReleaser.
 
 ## 1. Motivation & Background
 
-`goinstaller` v0 only understands GoReleaser YAML.  That prevents support for
+The earlier `goinstaller` prototype (pre‑rename) only understood GoReleaser YAML.  That prevents support for
 many projects that:
 
 * hand‑craft release assets (Rust, Zig, C/C++ projects, …)
@@ -54,7 +54,7 @@ R5  Provide machine validation for structure, defaults, enums.
 R6  Remain VCS‑friendly (no generated binary blobs inside repo).
 
 R7  Schema must be forward‑compatible: new, unknown fields must be safely
-    ignored by an older `goinstaller` binary, while a newer binary can still
+ignored by an older `binstaller` binary, while a newer binary can still
     understand old specs without a migration step.
 
 ## 3. InstallSpec v1 – High‑level Structure
@@ -115,7 +115,7 @@ unpack:
 Placeholders are replaced *verbatim* after all aliasing and naming‑convention
 normalisation has taken place.  They are always replaced as plain strings; no
 shell quoting is attempted inside the template – the caller (usually
-`goinstaller`) is responsible for quoting paths when executing commands.
+`binstaller`) is responsible for quoting paths when executing commands.
 
 ### 3.2 Asset resolution flow
 
@@ -175,7 +175,7 @@ This feature is particularly valuable for enterprise environments, air-gapped sy
 The `embed-checksums` command allows adding checksums from an existing checksum file to an InstallSpec config:
 
 ```bash
-goinstaller embed-checksums --config install-spec.yaml --checksum-file SHA256SUMS --version v1.2.3
+binstaller embed-checksums --config .binstaller.yml --checksum-file SHA256SUMS --version v1.2.3
 ```
 
 This command will:
@@ -191,7 +191,7 @@ The verification of checksums and attestations should be handled externally befo
 ## 4. Worked Example
 
 ```yaml
-# mycli-installspec.yml (abridged)
+# .binstaller.yml (abridged)
 
 name: mycli
 repo: acme/mycli
@@ -229,18 +229,18 @@ The InstallSpec is designed to work with a two-step workflow:
 
 1. **Config Generation**: First, generate the InstallSpec config file
    ```bash
-   goinstaller init-config --source [goreleaser|github|cli] [options]
+   binstaller init-config --source [goreleaser|github|cli] [options]
    ```
 
 2. **Script Generation**: Then, generate the installer script from the config
    ```bash
-   goinstaller generate-script --config install-spec.yaml [options]
+   binstaller generate-script --config .binstaller.yml [options]
    ```
 
 Additionally, a utility command is provided to embed checksums into an existing config:
 
 ```bash
-goinstaller embed-checksums --config install-spec.yaml --checksum-file SHA256SUMS --version v1.2.3
+binstaller embed-checksums --config .binstaller.yml --checksum-file SHA256SUMS --version v1.2.3
 ```
 
 This separation provides several benefits:
@@ -384,4 +384,5 @@ InstallSpec: {
     // maps to 'tar --strip-components=<n>'
     strip_components?: int | *0
   }
-}
+
+ }

--- a/docs/design/install-spec-v1.md
+++ b/docs/design/install-spec-v1.md
@@ -170,6 +170,24 @@ When `checksums.embedded_checksums` is provided, the generated installer script 
 
 This feature is particularly valuable for enterprise environments, air-gapped systems, or deployments in regions with unreliable internet connectivity.
 
+#### 3.3.4 Adding checksums to existing configs
+
+The `embed-checksums` command allows adding checksums from an existing checksum file to an InstallSpec config:
+
+```bash
+goinstaller embed-checksums --config install-spec.yaml --checksum-file SHA256SUMS --version v1.2.3
+```
+
+This command will:
+1. Parse the provided checksum file (e.g., SHA256SUMS)
+2. Extract checksums for assets that match the patterns defined in the config
+3. Add the checksums to the config under the `checksums.embedded_checksums` field for the specified version
+4. Save the updated config
+
+The verification of checksums and attestations should be handled externally before using this command. This approach allows for a clean separation of concerns, where:
+- Verification tools handle the security aspects
+- The `embed-checksums` command focuses solely on updating the config with pre-verified checksums
+
 ## 4. Worked Example
 
 ```yaml
@@ -203,8 +221,37 @@ Running on **Windows amd64** yields
 `mycli-v2.3.4-windows-amd64.zip` because the extension override rule in Section
 3 applies.
 
+## 5. Two-Step Workflow
 
-## 5. Schema definition (CUE)
+The InstallSpec is designed to work with a two-step workflow:
+
+> **Note**: These examples represent the current design thinking and may evolve during implementation. The exact command names, flags, and syntax are subject to change.
+
+1. **Config Generation**: First, generate the InstallSpec config file
+   ```bash
+   goinstaller init-config --source [goreleaser|github|cli] [options]
+   ```
+
+2. **Script Generation**: Then, generate the installer script from the config
+   ```bash
+   goinstaller generate-script --config install-spec.yaml [options]
+   ```
+
+Additionally, a utility command is provided to embed checksums into an existing config:
+
+```bash
+goinstaller embed-checksums --config install-spec.yaml --checksum-file SHA256SUMS --version v1.2.3
+```
+
+This separation provides several benefits:
+- The InstallSpec file can be inspected, validated, and version-controlled
+- The same config can be reused to generate different types of installer scripts (shell, PowerShell)
+- The script generation step becomes simpler and more focused
+- Checksums can be added to existing configs from external checksum files
+
+For more details on the workflow and command-line interface, see the [Architecture document](generic-installer-architecture.md).
+
+## 6. Schema definition (CUE)
 
 ```cue
 // InstallSpec defines the on-disk schema for the installer configuration.

--- a/docs/design/install-spec-v1.md
+++ b/docs/design/install-spec-v1.md
@@ -208,8 +208,12 @@ InstallSpec: {
 1. Per‑rule `bin` / `bin_path` overrides – do we need them in v1?
 2. Support for non‑GitHub hosts (GitLab, self‑hosted, S3).
 3. What should be the default `strip_components` (0 vs 1)?
-4. Formalise semantic‑versioning story for the schema itself (`schema: v1`
-   vs `schema: v1alpha1`, transition period, feature‑guarding, etc.).
+4. Formalise semantic‑versioning story for the schema itself (`schema: v1.0.0`
+   vs `schema: v1.1.0`, transition period, feature‑guarding, etc.). Schema
+   versioning will follow Semantic Versioning 2.0.0 (SemVer). Major versions
+   (e.g., `v2.0.0`) indicate breaking changes. Minor versions (e.g., `v1.1.0`)
+   introduce backward-compatible features. Patch versions (e.g., `v1.0.1`)
+   represent backward-compatible bug fixes or clarifications to the schema.
 
 ---
 

--- a/docs/design/install-spec-v1.md
+++ b/docs/design/install-spec-v1.md
@@ -2,7 +2,7 @@
 title: "InstallSpec v1 – Unified Installer Schema"
 date: "2025-04-19"
 author: "haya14busa"
-collaborators: ["codex (OpenAI o3)", "GitHub Copilot (Gemini 2.5 Pro, o4-mini)"]
+collaborators: ["codex (OpenAI o3)", "GitHub Copilot (Gemini 2.5 Pro, o4-mini)", "Roo Code (claude sonnet 3.7"]
 status: "draft"
 parent: generic-installer-architecture.md
 ---

--- a/docs/design/install-spec-v1.md
+++ b/docs/design/install-spec-v1.md
@@ -1,0 +1,212 @@
+---
+title: "InstallSpec v1 – Unified Installer Schema"
+date: "2025-04-19"
+author: "haya14busa"
+collaborators: ["OpenAI o3"]
+status: "draft"
+---
+
+# InstallSpec v1 – Design Document (DRAFT)
+
+This document records the design of **InstallSpec v1**, the first public,
+stable on‑disk schema that `goinstaller` consumes to generate cross‑platform
+installer scripts.  The schema intentionally focuses on *what to install*;
+*how the file was produced* (GoReleaser, hand‑crafted, Buildkite, …) is out of
+scope and left to pluggable **Source Adapters**.
+
+The primary audience is maintainers of CLI tools who wish to publish GitHub
+release assets that “just work” with a single, predictable `curl | sh`
+one‑liner without constraining their build pipeline to GoReleaser.
+
+## 1. Motivation & Background
+
+`goinstaller` v0 only understands GoReleaser YAML.  That prevents support for
+many projects that:
+
+* hand‑craft release assets (Rust, Zig, C/C++ projects, …)
+* use different naming conventions (e.g. `macOS` vs `darwin`, `x86_64` vs
+  `amd64`)
+* ship multiple vendor variants of the *same* OS/ARCH (e.g. `gnu`, `msvc`,
+  `musl`)
+
+To unlock those cases we introduce **InstallSpec**, a single document that
+describes *what* to download and install.  *Where* the information came from
+(GoReleaser YAML, GitHub API probing, CLI flags…) is handled by pluggable
+“SourceAdapters” upstream.
+
+## 2. Design Requirements
+
+R1  Single text file (YAML/JSON) that end‑users can also hand‑edit.
+
+R2  Concisely express common patterns; avoid having to enumerate every
+    OS/ARCH/variant combination.
+
+R3  Handle naming irregularities (capitalisation, aliases, vendor variants).
+
+R4  Allow runtime auto‑detection *and* explicit override of variants.
+
+R5  Provide machine validation for structure, defaults, enums.
+
+R6  Remain VCS‑friendly (no generated binary blobs inside repo).
+
+R7  Schema must be forward‑compatible: new, unknown fields must be safely
+    ignored by an older `goinstaller` binary, while a newer binary can still
+    understand old specs without a migration step.
+
+## 3. InstallSpec v1 – High‑level Structure
+
+```yaml
+schema: v1                # omitted ⇒ v1
+name: gh                  # binary name
+repo: cli/cli             # GitHub owner/repo
+
+default_version: latest   # optional fallback tag
+
+variant:
+  detect:  true           # runtime heuristic (default true)
+  default: gnu            # value when detect fails
+  choices: [gnu, msvc, musl]
+
+asset:
+  template: "${NAME}-v${VERSION}-${ARCH}-${OS}${EXT}"
+
+  rules:                  # first match wins
+    - when: { os: windows }
+      ext:  ".zip"       # extension override only
+    - when: { os: linux, arch: arm }
+      template: "${NAME}-v${VERSION}-arm-unknown-${OS}-${VARIANT}${EXT}"
+      ext:  ".tar.gz"
+
+  os_alias:   { darwin: macOS, windows: Windows }
+  arch_alias: { amd64: x86_64, arm64: aarch64 }
+
+  naming_convention:      # how uname output is normalised
+    os:   go             # go | uname | title
+    arch: go             # go | uname
+
+checksums:
+  template: "${NAME}-v${VERSION}-checksums.txt"
+  algorithm: sha256
+
+unpack:
+  strip_components: 1
+```
+
+### 3.1 Placeholders recognised in templates
+
+`${NAME}` `${VERSION}` `${OS}` `${ARCH}` `${EXT}` `${VARIANT}`
+
+Placeholders are replaced *verbatim* after all aliasing and naming‑convention
+normalisation has taken place.  They are always replaced as plain strings; no
+shell quoting is attempted inside the template – the caller (usually
+`goinstaller`) is responsible for quoting paths when executing commands.
+
+### 3.2 Asset resolution flow
+
+1. Canonicalise OS/ARCH according to `naming_convention`.
+2. Apply alias maps.
+3. Decide `VARIANT` using: CLI flag → auto detection → default.
+4. Walk `asset.rules`; first matching `when` wins.
+5. Combine `template` & `ext` overrides, then substitute placeholders.
+
+## 4. Worked Example
+
+```yaml
+# mycli-installspec.yml (abridged)
+
+name: mycli
+repo: acme/mycli
+
+asset:
+  template: "${NAME}-v${VERSION}-${OS}-${ARCH}${EXT}"
+
+checksums:
+  template: "${NAME}-v${VERSION}-checksums.txt"
+```
+
+If a user executes the generated installer on **macOS arm64** requesting
+version `v2.3.4`, resolution proceeds as follows:
+
+1. `OS` / `ARCH` normalise to `darwin` / `arm64` (Go convention).
+2. No `asset.rules` match; default `.tar.gz` is kept from the global `EXT`.
+3. Placeholders are substituted →
+
+   `mycli-v2.3.4-darwin-arm64.tar.gz`
+
+4. The checksum file becomes →
+
+   `mycli-v2.3.4-checksums.txt`
+
+Running on **Windows amd64** yields
+
+`mycli-v2.3.4-windows-amd64.zip` because the extension override rule in Section
+3 applies.
+
+
+## 5. Schema definition (CUE)
+
+CUE was selected over Protocol Buffers / JSON‑Schema because:
+
+* schema, defaults and validation live in *one* concise file;
+* YAML/JSON can be directly imported/merged;
+* Go code generation is officially supported;
+* no runtime library is required for YAML reading – decoding still happens via
+  the generated Go structs.
+
+```cue
+// installspect.cue – abridged
+
+InstallSpec: {
+  schema?: "v1" | *"v1"
+  name:    string
+  repo:    =~"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+"
+
+  default_version?: string | *"latest"
+
+  variant?: {
+    detect?:  bool | *true
+    default:  string
+    choices?: [...string] & >=1
+  }
+
+  asset: {
+    template: string & =~".*\\${VERSION}.*"
+
+    rules?: [...{
+      when: { os?: string, arch?: string, variant?: string }
+      template?: string
+      ext?:      string
+    }]
+
+    os_alias?:   { [string]: string }
+    arch_alias?: { [string]: string }
+
+    naming_convention?: {
+      os:   "go" | "uname" | "title" | *"go"
+      arch: "go" | "uname" | *"go"
+    }
+  }
+
+  checksums?: {
+    template:  string
+    algorithm?: "sha256" | "sha512" | *"sha256"
+    per_asset?: bool | *false
+  }
+
+  unpack?: {
+    strip_components?: int | *0
+  }
+}
+```
+
+## 6. Future Work / Open Questions
+
+1. Per‑rule `bin` / `bin_path` overrides – do we need them in v1?
+2. Support for non‑GitHub hosts (GitLab, self‑hosted, S3).
+3. What should be the default `strip_components` (0 vs 1)?
+4. Formalise semantic‑versioning story for the schema itself (`schema: v1`
+   vs `schema: v1alpha1`, transition period, feature‑guarding, etc.).
+
+---
+
+*Please leave comments directly on this document; improvements welcome.*

--- a/docs/design/install-spec-v1.md
+++ b/docs/design/install-spec-v1.md
@@ -172,10 +172,10 @@ This feature is particularly valuable for enterprise environments, air-gapped sy
 
 #### 3.3.4 Adding checksums to existing configs
 
-The `embed-checksums` command allows adding checksums from an existing checksum file to an InstallSpec config:
+The `binst embed` command allows adding checksums from an existing checksum file to an InstallSpec config:
 
 ```bash
-binstaller embed-checksums --config .binstaller.yml --checksum-file SHA256SUMS --version v1.2.3
+binst embed --config .binstaller.yml --checksum-file SHA256SUMS --version v1.2.3
 ```
 
 This command will:
@@ -186,7 +186,7 @@ This command will:
 
 The verification of checksums and attestations should be handled externally before using this command. This approach allows for a clean separation of concerns, where:
 - Verification tools handle the security aspects
-- The `embed-checksums` command focuses solely on updating the config with pre-verified checksums
+- The `binst embed` command focuses solely on updating the config with pre‑verified checksums
 
 ## 4. Worked Example
 
@@ -240,7 +240,7 @@ The InstallSpec is designed to work with a two-step workflow:
 Additionally, a utility command is provided to embed checksums into an existing config:
 
 ```bash
-binstaller embed-checksums --config .binstaller.yml --checksum-file SHA256SUMS --version v1.2.3
+binst embed --config .binstaller.yml --checksum-file SHA256SUMS --version v1.2.3
 ```
 
 This separation provides several benefits:

--- a/docs/design/install-spec-v1.md
+++ b/docs/design/install-spec-v1.md
@@ -4,15 +4,19 @@ date: "2025-04-19"
 author: "haya14busa"
 collaborators: ["OpenAI o3"]
 status: "draft"
+parent: generic-installer-architecture.md
 ---
 
 # InstallSpec v1 – Design Document (DRAFT)
 
-This document records the design of **InstallSpec v1**, the first public,
-stable on‑disk schema that `goinstaller` consumes to generate cross‑platform
-installer scripts.  The schema intentionally focuses on *what to install*;
-*how the file was produced* (GoReleaser, hand‑crafted, Buildkite, …) is out of
-scope and left to pluggable **Source Adapters**.
+This document is **part 2** of the *Generic Config‑Driven Installer* series.  It
+defines **InstallSpec v1**, the first public, stable on‑disk schema that
+`goinstaller` consumes to generate cross‑platform installer scripts (see
+*[Architecture]*](generic-installer-architecture.md) for the high‑level design).
+
+InstallSpec focuses on *what to install*; *how the file was produced*
+(GoReleaser, hand‑crafted, Buildkite, …) is out of scope and handled by the
+pluggable **Source Adapters** described in the architecture document.
 
 The primary audience is maintainers of CLI tools who wish to publish GitHub
 release assets that “just work” with a single, predictable `curl | sh`


### PR DESCRIPTION
This PR adds two new design documents for the generic installer architecture:

## New Design Documents

1. **Generic Installer Architecture (generic-installer-architecture.md)**
   - Outlines the high-level architecture for a config-driven installer pipeline
   - Defines the SourceAdapter interface, InstallSpec schema, and ScriptBuilder components
   - Includes CLI UX examples and implementation roadmap
   - Features a detailed section on embedded checksums benefits

2. **InstallSpec v1 (install-spec-v1.md)**
   - Defines the first stable on-disk schema for goinstaller
   - Provides detailed specification of placeholders, asset resolution, and embedded checksums
   - Includes worked examples and complete CUE schema definition
   - Documents the benefits of embedded checksums for performance, reliability, security, and UX

These documents lay the foundation for making goinstaller more flexible and not tied to GoReleaser, allowing it to support projects with custom asset naming conventions and release workflows.